### PR TITLE
Document the config file as _hugodown.yaml

### DIFF
--- a/vignettes/config.Rmd
+++ b/vignettes/config.Rmd
@@ -110,6 +110,6 @@ From easiest to hardest, based on the theme you chose:
 
 ## hugodown
 
-hugodown also has its own configuration file, `_hugodown.yml`. Currently this has one option:
+hugodown also has its own configuration file, `_hugodown.yaml`. Currently this has one option:
 
 -   `hugo_version`: this defines the version of hugo needed by the current site.


### PR DESCRIPTION
Currently the config refers to the config file as `_hugodown.yml` which is ignored.